### PR TITLE
Add a WebSocket reconnect on a user language change

### DIFF
--- a/cobalt/backend/application/contracts/services/settings.py
+++ b/cobalt/backend/application/contracts/services/settings.py
@@ -7,7 +7,8 @@ from abc import ABC, abstractmethod
 
 from application.dtos import (
     SettingsDto,
-    SettingsUpdateDto
+    SettingsUpdateDto,
+    UserDto
 )
 
 
@@ -20,6 +21,7 @@ class AbstractSettingsService(ABC):
     async def update_one(
         self,
         user_id: int,
+        current_user: UserDto,
         dto: SettingsUpdateDto
     ) -> SettingsDto:
         """
@@ -27,6 +29,7 @@ class AbstractSettingsService(ABC):
 
         Parameters:
         - user_id: User ID.
+        - current_user: UserDto object.
         - dto: SettingsUpdateDto object.
 
         Returns:

--- a/cobalt/backend/application/services/settings.py
+++ b/cobalt/backend/application/services/settings.py
@@ -14,11 +14,14 @@ from domain.exceptions import (
     NotFoundError,
     ConflictError
 )
-from domain.repositories import AbstractSettingsRepository
 from domain.enums import ServerStatusEnum
+from domain.repositories import AbstractSettingsRepository
 from application.contracts.loggers import AbstractLogger
 from application.contracts.queues import AbstractQueue
-from application.contracts.managers import AbstractI18nManager
+from application.contracts.managers import (
+    AbstractI18nManager,
+    AbstractConnectionsManager
+)
 from application.contracts.clients import AbstractCachesClient
 from application.contracts.clients import AbstractContainersClient
 from application.contracts.services import (
@@ -31,7 +34,8 @@ from application.clients.containers.shared import ContainersConstants
 from application.dtos import (
     SettingsDto,
     SettingsUpdateDto,
-    ServersGetPageDto
+    ServersGetPageDto,
+    UserDto
 )
 
 
@@ -44,6 +48,7 @@ class SettingsService(AbstractSettingsService):
     settings_mapper: AbstractSettingsServiceMapper
     containers_client: AbstractContainersClient
     servers_service: AbstractServersService
+    connections_manager: AbstractConnectionsManager
     i18n_manager: AbstractI18nManager
     queue: AbstractQueue
     logger: AbstractLogger
@@ -58,6 +63,7 @@ class SettingsService(AbstractSettingsService):
         settings_mapper: AbstractSettingsServiceMapper,
         containers_client: AbstractContainersClient,
         servers_service: AbstractServersService,
+        connections_manager: AbstractConnectionsManager,
         i18n_manager: AbstractI18nManager,
         queue: AbstractQueue,
         logger: AbstractLogger,
@@ -68,6 +74,7 @@ class SettingsService(AbstractSettingsService):
         self.settings_mapper = settings_mapper
         self.containers_client = containers_client
         self.servers_service = servers_service
+        self.connections_manager = connections_manager
         self.i18n_manager = i18n_manager
         self.queue = queue
         self.logger = logger
@@ -183,6 +190,7 @@ class SettingsService(AbstractSettingsService):
     async def update_one(
         self,
         user_id: int,
+        current_user: UserDto,
         dto: SettingsUpdateDto
     ) -> SettingsDto:
         """
@@ -190,6 +198,7 @@ class SettingsService(AbstractSettingsService):
 
         Parameters:
         - user_id: User ID.
+        - current_user: UserDto object.
         - dto: SettingsUpdateDto object.
 
         Returns:
@@ -222,6 +231,11 @@ class SettingsService(AbstractSettingsService):
                 )
             ]
         )
+
+        if current_user.settings.language != updated_entity.language:
+            await self.connections_manager.disconnect(
+                connection_id=current_user.id
+            )
 
         return self.settings_mapper.entity_to_dto(
             entity=updated_entity

--- a/cobalt/backend/composition/services.py
+++ b/cobalt/backend/composition/services.py
@@ -129,6 +129,7 @@ def create_settings_service(
     settings_repository: AbstractSettingsRepository,
     settings_mapper: AbstractSettingsServiceMapper,
     containers_client: AbstractContainersClient,
+    connections_manager: AbstractConnectionsManager,
     servers_service: AbstractServersService,
     queue: AbstractQueue,
     logger: AbstractLogger
@@ -144,6 +145,7 @@ def create_settings_service(
     - settings_mapper: AbstractSettingsServiceMapper object.
     - containers_client: AbstractContainersClient object.
     - servers_service: AbstractServersService object.
+    - connections_manager: AbstractConnectionsManager object.
     - queue: AbstractQueue object.
     - logger: AbstractLogger object.
 
@@ -157,6 +159,7 @@ def create_settings_service(
         settings_mapper=settings_mapper,
         containers_client=containers_client,
         servers_service=servers_service,
+        connections_manager=connections_manager,
         queue=queue,
         logger=logger,
         app_containers_dir=config.server.app_containers_dir
@@ -471,6 +474,7 @@ def create_services_container(
         settings_mapper=mappers.services.settings,
         containers_client=clients.containers,
         servers_service=servers_service,
+        connections_manager=managers.connections,
         queue=queue,
         logger=logger
     )

--- a/cobalt/backend/presentation/http/fastapi/v1/routers/settings.py
+++ b/cobalt/backend/presentation/http/fastapi/v1/routers/settings.py
@@ -118,6 +118,7 @@ class HttpSettingsRouter(AbstractHttpSettingsRouter, HttpBaseRouter):
 
         response_dto = await self.settings_service.update_one(
             user_id=request.state.user.id,
+            current_user=request.state.user,
             dto=request_dto
         )
 


### PR DESCRIPTION
This is necessary so that WebSocket errors are also translated into the current language.